### PR TITLE
Add link to live demo in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 - CSS
   So far..
 
+## Live Demo
+
+[Portfolio Live Demo](https://paulinagonzalezc.github.io/portfolio/)
+
 ## Getting Started
 
 More instructions comming soon.


### PR DESCRIPTION
In this pull request I:
* Deployed my website using GitHub Pages.
* Updated the README of my repository to include a link to the online version.